### PR TITLE
rust-toolchain: Update

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 # This file is automatically updated by the `update-rust-toolchain` action.
 [toolchain]
-channel = "1.68.0"
+channel = "1.69.0"
 components = ["rustfmt", "clippy", "rust-analysis"]
 targets = [ ]


### PR DESCRIPTION
Automatic change by the [update-rust-toolchain](https://github.com/a-kenji/update-rust-toolchain) Github Action.

Github Actions will not run workflows on pull requests which are opened by a GitHub Action.

For examples on how to run workflows on this pr, please go to the [readme](https://github.com/a-kenji/update-rust-toolchain/blob/main/README.md#running-github-actions-on-the-action).